### PR TITLE
added newestFirst query param

### DIFF
--- a/models/book.js
+++ b/models/book.js
@@ -52,10 +52,12 @@ Book.prototype.newJournalEntry = function(memo, date = null) {
  * @param query.startDate {string|number}
  * @param query.endDate {string|number}
  * @param query.memo {string}
+ * @param query.newestFirst {boolean} Order results by desc timestamp, (default : false).
  * @return Promise<JournalEntry[]>
  */
 Book.prototype.getJournalEntries = function(query) {
     const parsedQuery = parseQuery(this.getDataValue('id'), query);
+    parsedQuery.order = parsedQuery.order || [['timestamp', 'ASC']];
     return JournalEntry.findAll(parsedQuery).then(rows => {
         const results = rows.map(r => r.values());
         return results;
@@ -107,7 +109,7 @@ Book.prototype.getBalance = function(query, inQuoteCurrency = false) {
 };
 
 /**
- * Return all transactions ordered by time for a given book (subject to the constraints passed in the query)
+ * Return all journal entries ordered by time for a given book (subject to the constraints passed in the query)
  * @param query
  * @param query.startDate {string|number} Anything parseable by new Date()
  * @param query.endDate {string|number} Anything parseable by new Date()

--- a/models/book.js
+++ b/models/book.js
@@ -117,7 +117,7 @@ Book.prototype.getBalance = function(query, inQuoteCurrency = false) {
  */
 Book.prototype.getLedger = function(query) {
     query = parseQuery(this.get('id'), query);
-    query.order = [['timestamp', 'ASC']];
+    query.order = query.order || [['timestamp', 'ASC']];
     query.include = [ Transaction ];
     return JournalEntry.findAll(query);
 };
@@ -132,7 +132,7 @@ Book.prototype.getLedger = function(query) {
  */
 Book.prototype.getTransactions = function(query) {
     query = parseQuery(this.get('id'), query);
-    query.order = [['timestamp', 'ASC']];
+    query.order = query.order || [['timestamp', 'ASC']];
     return Transaction.findAll(query);
 };
 
@@ -259,6 +259,10 @@ function parseQuery(id, query) {
         parsed.where.memo = {[Op.or]: [query.memo, `${query.memo} [REVERSED]`]};
         delete query.memo;
     }
+    if (query.order) {
+        parsed.order = [['timestamp', query.order === 'DESC' ? 'DESC' : 'ASC']];
+    }
+
     return parsed;
 }
 

--- a/models/book.js
+++ b/models/book.js
@@ -113,6 +113,7 @@ Book.prototype.getBalance = function(query, inQuoteCurrency = false) {
  * @param query.endDate {string|number} Anything parseable by new Date()
  * @param query.perPage {number} Limit results to perPage
  * @param query.page {number} Return page number
+ * @param query.newestFirst {boolean} Order results by desc timestamp, (default : false).
  * @return {Array} of JournalEntry
  */
 Book.prototype.getLedger = function(query) {
@@ -128,7 +129,8 @@ Book.prototype.getLedger = function(query) {
  * @param query.account {string|Array} A single, or array of accounts to match. Assets will match Assets and Assets:*
  * @param query.perPage {number} Limit results to perPage
  * @param query.page {number} Return page number
- * @return {Array} of JournalEntry
+ * @param query.newestFirst {boolean} Order results by desc timestamp, (default : false).
+ * @return {Array} of Transaction
  */
 Book.prototype.getTransactions = function(query) {
     query = parseQuery(this.get('id'), query);
@@ -259,8 +261,8 @@ function parseQuery(id, query) {
         parsed.where.memo = {[Op.or]: [query.memo, `${query.memo} [REVERSED]`]};
         delete query.memo;
     }
-    if (query.order) {
-        parsed.order = [['timestamp', query.order === 'DESC' ? 'DESC' : 'ASC']];
+    if (query.newestFirst) {
+        parsed.order = [['timestamp', 'DESC']];
     }
 
     return parsed;

--- a/test/1_test.js
+++ b/test/1_test.js
@@ -190,4 +190,15 @@ describe('ALE', () => {
                 assert.equal(result[1].debit, 500);
             });
     });
+
+    it('should return newest transactions first when requested', () => {
+        return bookZAR.getJournalEntries()
+            .then((res) => {
+                assert(new Date(res[0].timestamp) < new Date(res[1].timestamp));
+            })
+            .then(() => bookZAR.getJournalEntries({newestFirst: true}))
+            .then((res) => {
+                assert(new Date(res[0].timestamp) > new Date(res[1].timestamp));
+            });
+    })
 });


### PR DESCRIPTION
When querying transactions and journal entries, specifying the param `newestFirst = true` will order the results by descending timestamp, otherwise ascending is used. This affects pagination, the first page will contain the newest records.